### PR TITLE
Fix Conduit's lack of drops

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ modVersion = 0.5.0
 modPackage = com.almostreliable.kubeio
 modId = kubejs_enderio
 modName = KubeJS-EnderIO-Patched
-modAuthor = Almost Reliable, Pansmith, Samstone1000
+modAuthor = Almost Reliable, Pansmith, Raine
 modDescription = KubeJS integration for EnderIO, working on newer versions of EnderIO.
 
 # Project Dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ enableAccessWidener = false
 minecraftVersion = 1.20.1
 
 # Mod
-modVersion = 0.5.0
+modVersion = 0.5.1
 modPackage = com.almostreliable.kubeio
 modId = kubejs_enderio
 modName = KubeJS-EnderIO-Patched

--- a/src/main/java/com/almostreliable/kubeio/ModInitializer.java
+++ b/src/main/java/com/almostreliable/kubeio/ModInitializer.java
@@ -1,7 +1,6 @@
 package com.almostreliable.kubeio;
 
 import com.almostreliable.kubeio.enderio.EnderIOIntegration;
-import com.almostreliable.kubeio.enderio.conduit.CustomConduitEntry;
 import com.almostreliable.kubeio.kube.KubePlugin;
 import com.almostreliable.kubeio.kube.event.ConduitRegistryEvent;
 import com.almostreliable.kubeio.util.SmeltingFilterSynchronizer;
@@ -53,8 +52,8 @@ public final class ModInitializer {
     private static void onTabContents(BuildCreativeModeTabContentsEvent event) {
         if (event.getTabKey() != EIOCreativeTabs.CONDUITS) return;
 
-        for (CustomConduitEntry conduit : ConduitRegistryEvent.CONDUITS) {
-            event.accept(conduit.item());
-        }
+        ConduitRegistryEvent.CONDUITS.stream()
+            .sorted((one, two) -> one.transferRate() - two.transferRate())
+            .forEach(entry -> event.accept(entry.item()));
     }
 }

--- a/src/main/java/com/almostreliable/kubeio/enderio/conduit/CustomConduitEntry.java
+++ b/src/main/java/com/almostreliable/kubeio/enderio/conduit/CustomConduitEntry.java
@@ -2,4 +2,5 @@ package com.almostreliable.kubeio.enderio.conduit;
 
 import net.minecraft.world.item.Item;
 
-public record CustomConduitEntry(String id, String name, Item item) {}
+public record CustomConduitEntry(String id, String name, int transferRate, Item item) {
+}

--- a/src/main/java/com/almostreliable/kubeio/enderio/conduit/CustomEnergyConduitTicker.java
+++ b/src/main/java/com/almostreliable/kubeio/enderio/conduit/CustomEnergyConduitTicker.java
@@ -46,7 +46,6 @@ public class CustomEnergyConduitTicker
                 continue;
             }
 
-            int previousStored = energy.getEnergyStored();
             for (ConduitNode<?> otherNode : loadedNodes)
             {
                 for (Direction dir : Direction.values())

--- a/src/main/java/com/almostreliable/kubeio/enderio/conduit/CustomEnergyConduitType.java
+++ b/src/main/java/com/almostreliable/kubeio/enderio/conduit/CustomEnergyConduitType.java
@@ -10,20 +10,24 @@ import com.enderio.conduits.common.conduit.type.energy.EnergyConduitType;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.energy.IEnergyStorage;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.Objects;
 
 public class CustomEnergyConduitType extends TieredConduit<CustomEnergyConduitData> {
 
-    private final int transferRate;
+    private final ResourceLocation id;
     private final ConduitTicker<CustomEnergyConduitData> ticker;
-    @SuppressWarnings("AssignmentToSuperclassField")
-    public CustomEnergyConduitType(ResourceLocation tierName, int transferRate) {
+    public CustomEnergyConduitType(ResourceLocation tierName, ResourceLocation id,
+        int transferRate) {
         super(new ResourceLocation("forge:energy"), tierName, transferRate);
-        this.transferRate = transferRate;
+        this.id = id;
         this.ticker = new CustomEnergyConduitTicker(transferRate);
     }
 
@@ -39,7 +43,7 @@ public class CustomEnergyConduitType extends TieredConduit<CustomEnergyConduitDa
 
     @Override
     public CustomEnergyConduitData createConduitData(Level level, BlockPos pos) {
-        return new CustomEnergyConduitData(this.transferRate);
+        return new CustomEnergyConduitData(this.getTier());
     }
 
     @Override
@@ -66,5 +70,10 @@ public class CustomEnergyConduitType extends TieredConduit<CustomEnergyConduitDa
     public boolean canBeInSameBlock(ConduitType<?> other) {
         // don't allow simple energy conduit to be in the same block as custom energy conduits
         return !(other instanceof EnergyConduitType) && super.canBeInSameBlock(other);
+    }
+
+    @Override
+    public Item getConduitItem() {
+        return Objects.requireNonNull(ForgeRegistries.ITEMS.getValue(id));
     }
 }

--- a/src/main/java/com/almostreliable/kubeio/kube/event/ConduitRegistryEvent.java
+++ b/src/main/java/com/almostreliable/kubeio/kube/event/ConduitRegistryEvent.java
@@ -8,6 +8,7 @@ import com.enderio.conduits.common.init.EIOConduitTypes;
 import com.google.common.base.Preconditions;
 import dev.latvian.mods.kubejs.event.EventJS;
 import dev.latvian.mods.rhino.util.HideFromJS;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
@@ -28,9 +29,10 @@ public class ConduitRegistryEvent extends EventJS {
             "id must be unique"
         );
 
+        ResourceLocation itemId = EnderIO.loc(id);
         RegistryObject<CustomEnergyConduitType> type = EIOConduitTypes.CONDUIT_TYPES.register(id,
             () ->
-            new CustomEnergyConduitType(EnderIO.loc("block/conduit/" + id), EnderIO.loc(id),
+            new CustomEnergyConduitType(EnderIO.loc("block/conduit/" + id), itemId,
                 transferRate));
 
         // ConduitApi.INSTANCE.getConduitTypeRegistry()
@@ -39,7 +41,7 @@ public class ConduitRegistryEvent extends EventJS {
         // transferRate)
         // );
         Item item = ConduitItemFactory.build(type, new Item.Properties());
-        ForgeRegistries.ITEMS.register(EnderIO.loc(id), item);
+        ForgeRegistries.ITEMS.register(itemId, item);
 
         CONDUITS.add(new CustomConduitEntry(id, name, transferRate, item));
     }

--- a/src/main/java/com/almostreliable/kubeio/kube/event/ConduitRegistryEvent.java
+++ b/src/main/java/com/almostreliable/kubeio/kube/event/ConduitRegistryEvent.java
@@ -30,7 +30,8 @@ public class ConduitRegistryEvent extends EventJS {
 
         RegistryObject<CustomEnergyConduitType> type = EIOConduitTypes.CONDUIT_TYPES.register(id,
             () ->
-            new CustomEnergyConduitType(EnderIO.loc("block/conduit/" + id), transferRate));
+            new CustomEnergyConduitType(EnderIO.loc("block/conduit/" + id), EnderIO.loc(id),
+                transferRate));
 
         // ConduitApi.INSTANCE.getConduitTypeRegistry()
         // .register(id, new CustomEnergyConduitType(
@@ -40,6 +41,6 @@ public class ConduitRegistryEvent extends EventJS {
         Item item = ConduitItemFactory.build(type, new Item.Properties());
         ForgeRegistries.ITEMS.register(EnderIO.loc(id), item);
 
-        CONDUITS.add(new CustomConduitEntry(id, name, item));
+        CONDUITS.add(new CustomConduitEntry(id, name, transferRate, item));
     }
 }


### PR DESCRIPTION
Fixes conduits not dropping anything, which also fixes conduit's not being 'pick block'-able and not showing up in WAILA. Also fixed conduit's not being ordered in the creative tab, should probably check if EMI is ordered.

I bumped the version here too, technically shouldn't be done in a PR, but ¯\\\_(ツ)\_/¯. It's not like anyone else is working on this.